### PR TITLE
feat(dots-swe): Add tmux integration for worktree sessions

### DIFF
--- a/dots-swe/commands/help.md
+++ b/dots-swe/commands/help.md
@@ -19,6 +19,7 @@ Software engineering tools for Claude Code - worktree management, beads integrat
 | `/dots-swe:worktree-list` | List all worktrees |
 | `/dots-swe:worktree-sync [name]` | Sync worktree with main branch |
 | `/dots-swe:worktree-status` | Dashboard showing all worktrees |
+| `/dots-swe:worktree-attach [session]` | Re-attach iTerm2 to tmux sessions |
 | `/dots-swe:worktree-delete <name>` | Delete worktree(s) and clean up |
 
 ### Beads Integration
@@ -84,6 +85,12 @@ git commit -m "feat: Add feature"
 **Context Files:**
 - `.swe-bead` - Bead ID for current worktree
 - `.swe-context` - Task context and quick reference
+- `.tmux-session` - tmux session name for this worktree
+
+**tmux Integration:**
+- Worktrees from the same epic share a tmux session (appear as tabs)
+- Re-attach after iTerm2 restart: `/dots-swe:worktree-attach <session>`
+- Sessions persist even when iTerm2 closes
 
 ## Learn More
 

--- a/dots-swe/commands/worktree-attach.md
+++ b/dots-swe/commands/worktree-attach.md
@@ -1,0 +1,59 @@
+---
+allowed-tools: Bash(tmux:*), Bash(osascript:*), Bash(source:*)
+description: Re-attach iTerm2 to existing tmux sessions
+---
+
+# Re-attach to Worktree Sessions
+
+Re-attaches iTerm2 to existing tmux sessions after restart.
+
+**Usage:** `/dots-swe:worktree-attach [session-name]`
+
+**Examples:**
+```bash
+/dots-swe:worktree-attach              # List available sessions
+/dots-swe:worktree-attach yap-tsd      # Attach to specific session
+```
+
+## Implementation
+
+!source "${CLAUDE_PLUGIN_ROOT}/scripts/swe-lib.sh"
+
+# Help flag
+!if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+  echo "Usage: /dots-swe:worktree-attach [session-name]"
+  echo ""
+  echo "Re-attach iTerm2 to existing tmux sessions."
+  echo ""
+  echo "Without arguments, lists available tmux sessions."
+  echo "With a session name, attaches iTerm2 to that session."
+  echo ""
+  echo "Examples:"
+  echo "  /dots-swe:worktree-attach              # List sessions"
+  echo "  /dots-swe:worktree-attach yap-tsd      # Attach to yap-tsd"
+  exit 0
+fi
+
+# List or attach
+!if [ -n "$1" ]; then
+  SESSION="$1"
+  if tmux_session_exists "$SESSION"; then
+    echo "Attaching iTerm2 to tmux session: $SESSION"
+    attach_iterm_to_tmux "$SESSION"
+    echo ""
+    echo "Session windows:"
+    tmux list-windows -t "$SESSION" 2>/dev/null
+  else
+    echo "ERROR: Session '$SESSION' not found"
+    echo ""
+    echo "Available sessions:"
+    tmux list-sessions 2>/dev/null || echo "  (no tmux sessions running)"
+    exit 1
+  fi
+else
+  echo "Available tmux sessions:"
+  echo ""
+  tmux list-sessions 2>/dev/null || echo "  (no tmux sessions running)"
+  echo ""
+  echo "Usage: /dots-swe:worktree-attach <session-name>"
+fi


### PR DESCRIPTION
## Summary

- Add tmux session management to dots-swe plugin
- Features from the same epic share a single tmux session (appear as iTerm2 tabs)
- Claude starts with `--dangerously-skip-permissions --model opus`
- Sessions persist when iTerm2 closes for easy re-attachment
- Add `/dots-swe:worktree-attach` command for reconnecting

## Changes

**`dots-swe/scripts/swe-lib.sh`:**
- `get_claude_options()` - configurable Claude startup flags
- `get_tmux_session_name()` - extracts epic from bead ID (yap-tsd.1 → yap-tsd)
- tmux functions: create_tmux_session, add_tmux_window, start_claude_in_window
- `attach_iterm_to_tmux()` - AppleScript to connect iTerm2 via tmux -CC
- `open_tmux_worktree()` - creates session/window as needed
- Updated `open_and_register_worktrees()` to attach iTerm2 after all windows created

**New command:** `/dots-swe:worktree-attach [session]`

**Updated:** `help.md` with tmux documentation

## Test plan

- [ ] Kill tmux: `tmux kill-server`
- [ ] Run `/dots-swe:work <bead-id>` for a feature
- [ ] Verify tmux session created with correct name
- [ ] Verify iTerm2 opens with tab
- [ ] Verify Claude starts with correct options
- [ ] Add second feature from same epic, verify new tab (not window)
- [ ] Quit iTerm2, verify `tmux list-sessions` still shows session
- [ ] Run `/dots-swe:worktree-attach <session>`, verify reconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)